### PR TITLE
BOO-8414: [remote_config] Return null for missing parameters

### DIFF
--- a/remote_config/.gitignore
+++ b/remote_config/.gitignore
@@ -1,1 +1,2 @@
+.flutter-plugins-dependencies
 pubspec.lock

--- a/remote_config/lib/src/entity/default_remote_config_parameter.dart
+++ b/remote_config/lib/src/entity/default_remote_config_parameter.dart
@@ -24,14 +24,13 @@ final class DefaultRemoteConfigParameter {
 
   /// Gets [T] parameter value.
   /// Supported types are: String, int, double, bool.
-  Future<Result<T>> getValue<T extends Object>() {
+  /// Returns null if the parameter with [_parameterKey] is not configured in remote config.
+  Future<Result<T?>> getValue<T extends Object>() {
     return _remoteConfigValueProvider.call(parameterKey: _parameterKey).flatMapAsync((
       RemoteConfigValue remoteConfigValue,
     ) {
       return switch (remoteConfigValue.source) {
-        ValueSource.valueStatic => MissingRemoteConfigParameterForKeyFailure(
-          parameterKey: _parameterKey,
-        ).toFailureResult(),
+        ValueSource.valueStatic => null.toSuccessResult(),
         ValueSource.valueDefault || ValueSource.valueRemote => _decodeRemoteConfigValue(remoteConfigValue),
       };
     });
@@ -39,14 +38,16 @@ final class DefaultRemoteConfigParameter {
 
   /// Gets parameter value as collection of [T] values.
   /// Supported collection types are: List, Set.
-  Future<Result<CollectionT>> getCollectionValue<T, CollectionT extends Iterable<T>>() {
-    return _getJsonValue<Iterable<Object?>>().flatMapAsync((Iterable<Object?> collection) {
+  /// Returns null if the parameter with [_parameterKey] is not configured in remote config.
+  Future<Result<CollectionT?>> getCollectionValue<T, CollectionT extends Iterable<T>>() {
+    return _getJsonValue<Iterable<Object?>>().flatMapNotNullValueAsync((Iterable<Object?> collection) {
       return decodeCollectionValue<T, CollectionT>(collection);
     });
   }
 
   /// Gets parameter value as `Map<String, Object?>`.
-  Future<Result<Map<String, Object?>>> getJsonMapValue() => _getJsonValue();
+  /// Returns null if the parameter with [_parameterKey] is not configured in remote config.
+  Future<Result<Map<String, Object?>?>> getJsonMapValue() => _getJsonValue();
 
   /// Decodes value from [valueProvider].
   Result<T> decodeValue<T>(T Function() valueProvider) {
@@ -81,8 +82,8 @@ final class DefaultRemoteConfigParameter {
     }).flatMapNullValueToFailure(() => const UnsupportedRemoteConfigParameterValueTypeFailure());
   }
 
-  Future<Result<JsonT>> _getJsonValue<JsonT extends Object>() {
-    return getValue<String>().flatMapAsync((String jsonString) {
+  Future<Result<JsonT?>> _getJsonValue<JsonT extends Object>() {
+    return getValue<String>().flatMapNotNullValueAsync((String jsonString) {
       return mapToResult(
         valueProvider: () => jsonDecode(jsonString) as JsonT,
         failureProvider: RemoteConfigJsonParameterValueDecodingFailure.new,

--- a/remote_config/lib/src/entity/labels_segmented_remote_config_parameter.dart
+++ b/remote_config/lib/src/entity/labels_segmented_remote_config_parameter.dart
@@ -28,8 +28,11 @@ final class LabelsSegmentedRemoteConfigParameter {
 
   /// Gets [T] parameter value.
   /// Supported types are: String, int, double, bool.
-  Future<Result<T>> getValue<T extends Object>() {
-    return _defaultRemoteConfigParameter.getJsonMapValue().flatMapFuture((Map<String, Object?> jsonMap) {
+  /// Returns null if the parameter with [parameterKey] is not configured in remote config.
+  Future<Result<T?>> getValue<T extends Object>() {
+    return _defaultRemoteConfigParameter.getJsonMapValue().flatMapNotNullValueFuture((
+      Map<String, Object?> jsonMap,
+    ) {
       return getSegmentedValueFromJson(
         jsonMap,
         valueTransform: (Object? value) => _defaultRemoteConfigParameter.decodeValue(() => value! as T),
@@ -39,8 +42,9 @@ final class LabelsSegmentedRemoteConfigParameter {
 
   /// Gets parameter value as collection of [T] values.
   /// Supported collection types are: List, Set.
-  Future<Result<CollectionT>> getCollectionValue<T, CollectionT extends Iterable<T>>() {
-    return getValue<Iterable<Object?>>().flatMapAsync((Iterable<Object?> collection) {
+  /// Returns null if the parameter with [parameterKey] is not configured in remote config.
+  Future<Result<CollectionT?>> getCollectionValue<T, CollectionT extends Iterable<T>>() {
+    return getValue<Iterable<Object?>>().flatMapNotNullValueAsync((Iterable<Object?> collection) {
       return _defaultRemoteConfigParameter.decodeCollectionValue<T, CollectionT>(collection);
     });
   }

--- a/remote_config/lib/src/failure/remote_config_failure.dart
+++ b/remote_config/lib/src/failure/remote_config_failure.dart
@@ -42,22 +42,6 @@ final class FetchAndActivateRemoteConfigFailure implements RemoteConfigFailure {
   }
 }
 
-/// Failure for missing remote config parameter.
-class MissingRemoteConfigParameterForKeyFailure implements RemoteConfigFailure {
-  /// Creates a [MissingRemoteConfigParameterForKeyFailure].
-  const MissingRemoteConfigParameterForKeyFailure({
-    required this.parameterKey,
-  });
-
-  /// A key of the parameter.
-  final String parameterKey;
-
-  @override
-  String toString() {
-    return 'MissingRemoteConfigParameterForKeyFailure{parameterKey: $parameterKey}';
-  }
-}
-
 /// Failure during decoding remote config parameter value.
 class RemoteConfigParameterValueDecodingFailure implements RemoteConfigFailure {
   /// Creates a [RemoteConfigParameterValueDecodingFailure].

--- a/remote_config/lib/src/firebase_remote_config_service.dart
+++ b/remote_config/lib/src/firebase_remote_config_service.dart
@@ -47,51 +47,41 @@ final class FirebaseRemoteConfigService implements RemoteConfigService {
   /// Fires when config was fully initialized.
   Future<Result<void>> get _configInitialization => _configInitializationCompleter.future;
 
-  /// Awaits config initialization and gets [String] parameter value for selected [parameterKey].
   @override
-  Future<Result<String>> getStringParameterValue({required String parameterKey}) =>
+  Future<Result<String?>> getStringParameterValue({required String parameterKey}) =>
       _getDefaultParameterValue(parameterKey: parameterKey);
 
-  /// Awaits config initialization and gets [int] parameter value for selected [parameterKey].
   @override
-  Future<Result<int>> getIntParameterValue({required String parameterKey}) =>
+  Future<Result<int?>> getIntParameterValue({required String parameterKey}) =>
       _getDefaultParameterValue(parameterKey: parameterKey);
 
-  /// Awaits config initialization and gets [double] parameter value for selected [parameterKey].
   @override
-  Future<Result<double>> getDoubleParameterValue({required String parameterKey}) =>
+  Future<Result<double?>> getDoubleParameterValue({required String parameterKey}) =>
       _getDefaultParameterValue(parameterKey: parameterKey);
 
-  /// Awaits config initialization and gets [bool] parameter value for selected [parameterKey].
   @override
-  Future<Result<bool>> getBoolParameterValue({required String parameterKey}) =>
+  Future<Result<bool?>> getBoolParameterValue({required String parameterKey}) =>
       _getDefaultParameterValue(parameterKey: parameterKey);
 
-  /// Awaits config initialization and gets parameter value as List of [T] values
-  /// for selected [parameterKey].
   @override
-  Future<Result<List<T>>> getListParameterValue<T>({required String parameterKey}) {
+  Future<Result<List<T>?>> getListParameterValue<T>({required String parameterKey}) {
     return _getCollectionDefaultParameterValue<T, List<T>>(parameterKey: parameterKey);
   }
 
-  /// Awaits config initialization and gets parameter value as Set of [T] values
-  /// for selected [parameterKey].
   @override
-  Future<Result<Set<T>>> getSetParameterValue<T>({required String parameterKey}) {
+  Future<Result<Set<T>?>> getSetParameterValue<T>({required String parameterKey}) {
     return _getCollectionDefaultParameterValue<T, Set<T>>(parameterKey: parameterKey);
   }
 
-  /// Awaits config initialization and gets complex feature parameter value for selected [parameterKey].
-  /// On any thrown error from [featureFactory] will be returned [RemoteConfigFeatureParameterParsingFailure].
   @override
-  Future<Result<FeatureT>> getFeatureParameterValue<FeatureT extends Object>({
+  Future<Result<FeatureT?>> getFeatureParameterValue<FeatureT extends Object>({
     required String parameterKey,
     required FeatureT Function(Map<String, Object?> json) featureFactory,
   }) {
     return _getParameterValueWithDefaultRemoteConfigParameter(
       parameterKey: parameterKey,
       parameterValueProvider: (DefaultRemoteConfigParameter parameter) {
-        return parameter.getJsonMapValue().flatMapAsync((Map<String, Object?> jsonMap) {
+        return parameter.getJsonMapValue().flatMapNotNullValueAsync((Map<String, Object?> jsonMap) {
           try {
             return featureFactory.call(jsonMap).toSuccessResult();
           } catch (error) {
@@ -102,55 +92,40 @@ final class FirebaseRemoteConfigService implements RemoteConfigService {
     );
   }
 
-  /// Awaits config initialization and gets [String] labels segmented parameter value
-  /// for selected [parameterKey].
-  /// [userLabels] is a map of user labels where key is the label key and value is the label value.
   @override
-  Future<Result<String>> getStringLabelsSegmentedParameterValue({
+  Future<Result<String?>> getStringLabelsSegmentedParameterValue({
     required String parameterKey,
     required FutureOr<Map<String, String>> userLabels,
   }) {
     return _getLabelsSegmentedParameterValue(parameterKey: parameterKey, userLabels: userLabels);
   }
 
-  /// Awaits config initialization and gets [int] labels segmented parameter value
-  /// for selected [parameterKey].
-  /// [userLabels] is a map of user labels where key is the label key and value is the label value.
   @override
-  Future<Result<int>> getIntLabelsSegmentedParameterValue({
+  Future<Result<int?>> getIntLabelsSegmentedParameterValue({
     required String parameterKey,
     required FutureOr<Map<String, String>> userLabels,
   }) {
     return _getLabelsSegmentedParameterValue(parameterKey: parameterKey, userLabels: userLabels);
   }
 
-  /// Awaits config initialization and gets [double] labels segmented parameter value
-  /// for selected [parameterKey].
-  /// [userLabels] is a map of user labels where key is the label key and value is the label value.
   @override
-  Future<Result<double>> getDoubleLabelsSegmentedParameterValue({
+  Future<Result<double?>> getDoubleLabelsSegmentedParameterValue({
     required String parameterKey,
     required FutureOr<Map<String, String>> userLabels,
   }) {
     return _getLabelsSegmentedParameterValue(parameterKey: parameterKey, userLabels: userLabels);
   }
 
-  /// Awaits config initialization and gets [bool] labels segmented parameter value
-  /// for selected [parameterKey].
-  /// [userLabels] is a map of user labels where key is the label key and value is the label value.
   @override
-  Future<Result<bool>> getBoolLabelsSegmentedParameterValue({
+  Future<Result<bool?>> getBoolLabelsSegmentedParameterValue({
     required String parameterKey,
     required FutureOr<Map<String, String>> userLabels,
   }) {
     return _getLabelsSegmentedParameterValue(parameterKey: parameterKey, userLabels: userLabels);
   }
 
-  /// Awaits config initialization and gets parameter value as List of [T] values
-  /// for selected [parameterKey].
-  /// [userLabels] is a map of user labels where key is the label key and value is the label value.
   @override
-  Future<Result<List<T>>> getListLabelsSegmentedParameterValue<T>({
+  Future<Result<List<T>?>> getListLabelsSegmentedParameterValue<T>({
     required String parameterKey,
     required FutureOr<Map<String, String>> userLabels,
   }) {
@@ -160,11 +135,8 @@ final class FirebaseRemoteConfigService implements RemoteConfigService {
     );
   }
 
-  /// Awaits config initialization and gets parameter value as Set of [T] values
-  /// for selected [parameterKey].
-  /// [userLabels] is a map of user labels where key is the label key and value is the label value.
   @override
-  Future<Result<Set<T>>> getSetLabelsSegmentedParameterValue<T>({
+  Future<Result<Set<T>?>> getSetLabelsSegmentedParameterValue<T>({
     required String parameterKey,
     required FutureOr<Map<String, String>> userLabels,
   }) {
@@ -197,7 +169,7 @@ final class FirebaseRemoteConfigService implements RemoteConfigService {
     return _remoteConfig.fetchAndActivate().mapToResult(FetchAndActivateRemoteConfigFailure.new);
   }
 
-  Future<Result<T>> _getDefaultParameterValue<T extends Object>({required String parameterKey}) {
+  Future<Result<T?>> _getDefaultParameterValue<T extends Object>({required String parameterKey}) {
     return _getParameterValueWithDefaultRemoteConfigParameter(
       parameterKey: parameterKey,
       parameterValueProvider: (DefaultRemoteConfigParameter parameter) => parameter.getValue(),
@@ -219,7 +191,7 @@ final class FirebaseRemoteConfigService implements RemoteConfigService {
     return _configInitialization.mapAsync((_) => _remoteConfig.getValue(parameterKey));
   }
 
-  Future<Result<CollectionT>> _getCollectionDefaultParameterValue<T, CollectionT extends Iterable<T>>({
+  Future<Result<CollectionT?>> _getCollectionDefaultParameterValue<T, CollectionT extends Iterable<T>>({
     required String parameterKey,
   }) {
     return _getParameterValueWithDefaultRemoteConfigParameter(
@@ -229,7 +201,7 @@ final class FirebaseRemoteConfigService implements RemoteConfigService {
     );
   }
 
-  Future<Result<T>> _getLabelsSegmentedParameterValue<T extends Object>({
+  Future<Result<T?>> _getLabelsSegmentedParameterValue<T extends Object>({
     required String parameterKey,
     required FutureOr<Map<String, String>> userLabels,
   }) {
@@ -254,10 +226,11 @@ final class FirebaseRemoteConfigService implements RemoteConfigService {
     return parameterValueProvider.call(parameter);
   }
 
-  Future<Result<CollectionT>> _getCollectionLabelsSegmentedParameterValue<
-    T,
-    CollectionT extends Iterable<T>
-  >({required String parameterKey, required FutureOr<Map<String, String>> userLabels}) {
+  Future<Result<CollectionT?>>
+  _getCollectionLabelsSegmentedParameterValue<T, CollectionT extends Iterable<T>>({
+    required String parameterKey,
+    required FutureOr<Map<String, String>> userLabels,
+  }) {
     return _getValueWithLabelsSegmentedRemoteConfigParameter(
       parameterKey: parameterKey,
       userLabels: userLabels,

--- a/remote_config/lib/src/remote_config_service.dart
+++ b/remote_config/lib/src/remote_config_service.dart
@@ -6,76 +6,89 @@ import 'package:remote_config_service/src/failure/remote_config_failure.dart';
 /// An interface for a service that provides remote configuration parameters.
 abstract interface class RemoteConfigService {
   /// Awaits config initialization and gets [String] parameter value for selected [parameterKey].
-  Future<Result<String>> getStringParameterValue({required String parameterKey});
+  /// Returns null if the parameter with [parameterKey] is not configured in remote config.
+  Future<Result<String?>> getStringParameterValue({required String parameterKey});
 
   /// Awaits config initialization and gets [int] parameter value for selected [parameterKey].
-  Future<Result<int>> getIntParameterValue({required String parameterKey});
+  /// Returns null if the parameter with [parameterKey] is not configured in remote config.
+  Future<Result<int?>> getIntParameterValue({required String parameterKey});
 
   /// Awaits config initialization and gets [double] parameter value for selected [parameterKey].
-  Future<Result<double>> getDoubleParameterValue({required String parameterKey});
+  /// Returns null if the parameter with [parameterKey] is not configured in remote config.
+  Future<Result<double?>> getDoubleParameterValue({required String parameterKey});
 
   /// Awaits config initialization and gets [bool] parameter value for selected [parameterKey].
-  Future<Result<bool>> getBoolParameterValue({required String parameterKey});
+  /// Returns null if the parameter with [parameterKey] is not configured in remote config.
+  Future<Result<bool?>> getBoolParameterValue({required String parameterKey});
 
   /// Awaits config initialization and gets parameter value as List of [T] values
   /// for selected [parameterKey].
-  Future<Result<List<T>>> getListParameterValue<T>({required String parameterKey});
+  /// Returns null if the parameter with [parameterKey] is not configured in remote config.
+  Future<Result<List<T>?>> getListParameterValue<T>({required String parameterKey});
 
   /// Awaits config initialization and gets parameter value as Set of [T] values
   /// for selected [parameterKey].
-  Future<Result<Set<T>>> getSetParameterValue<T>({required String parameterKey});
+  /// Returns null if the parameter with [parameterKey] is not configured in remote config.
+  Future<Result<Set<T>?>> getSetParameterValue<T>({required String parameterKey});
 
   /// Awaits config initialization and gets complex feature parameter value for selected [parameterKey].
+  /// Returns null if the parameter with [parameterKey] is not configured in remote config.
   /// On any thrown error from [featureFactory] will be returned [RemoteConfigFeatureParameterParsingFailure].
-  Future<Result<FeatureT>> getFeatureParameterValue<FeatureT extends Object>({
+  Future<Result<FeatureT?>> getFeatureParameterValue<FeatureT extends Object>({
     required String parameterKey,
     required FeatureT Function(Map<String, Object?> json) featureFactory,
   });
 
   /// Awaits config initialization and gets [String] labels segmented parameter value
   /// for selected [parameterKey].
+  /// Returns null if the parameter with [parameterKey] is not configured in remote config.
   /// [userLabels] is a map of user labels where key is the label key and value is the label value.
-  Future<Result<String>> getStringLabelsSegmentedParameterValue({
+  Future<Result<String?>> getStringLabelsSegmentedParameterValue({
     required String parameterKey,
     required FutureOr<Map<String, String>> userLabels,
   });
 
   /// Awaits config initialization and gets [int] labels segmented parameter value
   /// for selected [parameterKey].
+  /// Returns null if the parameter with [parameterKey] is not configured in remote config.
   /// [userLabels] is a map of user labels where key is the label key and value is the label value.
-  Future<Result<int>> getIntLabelsSegmentedParameterValue({
+  Future<Result<int?>> getIntLabelsSegmentedParameterValue({
     required String parameterKey,
     required FutureOr<Map<String, String>> userLabels,
   });
 
   /// Awaits config initialization and gets [double] labels segmented parameter value
   /// for selected [parameterKey].
+  /// Returns null if the parameter with [parameterKey] is not configured in remote config.
   /// [userLabels] is a map of user labels where key is the label key and value is the label value.
-  Future<Result<double>> getDoubleLabelsSegmentedParameterValue({
+  Future<Result<double?>> getDoubleLabelsSegmentedParameterValue({
     required String parameterKey,
     required FutureOr<Map<String, String>> userLabels,
   });
 
   /// Awaits config initialization and gets [bool] labels segmented parameter value
   /// for selected [parameterKey].
+  /// Returns null if the parameter with [parameterKey] is not configured in remote config.
   /// [userLabels] is a map of user labels where key is the label key and value is the label value.
-  Future<Result<bool>> getBoolLabelsSegmentedParameterValue({
+  Future<Result<bool?>> getBoolLabelsSegmentedParameterValue({
     required String parameterKey,
     required FutureOr<Map<String, String>> userLabels,
   });
 
   /// Awaits config initialization and gets parameter value as List of [T] values
   /// for selected [parameterKey].
+  /// Returns null if the parameter with [parameterKey] is not configured in remote config.
   /// [userLabels] is a map of user labels where key is the label key and value is the label value.
-  Future<Result<List<T>>> getListLabelsSegmentedParameterValue<T>({
+  Future<Result<List<T>?>> getListLabelsSegmentedParameterValue<T>({
     required String parameterKey,
     required FutureOr<Map<String, String>> userLabels,
   });
 
   /// Awaits config initialization and gets parameter value as Set of [T] values
   /// for selected [parameterKey].
+  /// Returns null if the parameter with [parameterKey] is not configured in remote config.
   /// [userLabels] is a map of user labels where key is the label key and value is the label value.
-  Future<Result<Set<T>>> getSetLabelsSegmentedParameterValue<T>({
+  Future<Result<Set<T>?>> getSetLabelsSegmentedParameterValue<T>({
     required String parameterKey,
     required FutureOr<Map<String, String>> userLabels,
   });

--- a/remote_config/pubspec.yaml
+++ b/remote_config/pubspec.yaml
@@ -1,6 +1,6 @@
 name: remote_config_service
 description: Remote config service module
-version: 2.0.0
+version: 4.0.0
 publish_to: none
 
 environment:
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   async: ^2.13.0
-  firebase_remote_config: ^6.1.1
+  firebase_remote_config: ^6.4.0
   meta: ^1.17.0
 
   common_result:
@@ -20,4 +20,4 @@ dev_dependencies:
   common_package:
     git:
       url: git@github.com:nove8/fl-common-package.git
-      ref: 4.0.0
+      ref: 4.2.0


### PR DESCRIPTION
BREAKING CHANGE: all public API methods return Result<T?> instead of Result<T>.
BREAKING CHANGE: remove `MissingRemoteConfigParameterForKeyFailure`
chore: bump `firebase_remote_config` to `^6.4.0`
chore: bump `common_package` version to `4.2.0`
chore: add `.flutter-plugins-dependencies` to `.gitignore`